### PR TITLE
Fix layout alignment and grid issues

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -146,13 +146,13 @@ h1, h2, h3 {
 /* Hero Section */
 .hero {
     padding: var(--space-xl) 0 var(--space-lg);
-    max-width: 800px;
 }
 
 .hero h1 {
     margin-bottom: var(--space-md);
     font-size: 3rem;
     letter-spacing: -0.02em;
+    max-width: 800px;
 }
 
 .hero-subtitle {
@@ -169,6 +169,12 @@ h1, h2, h3 {
     font-family: var(--font-mono);
     font-size: 0.875rem;
     color: var(--text-muted);
+}
+
+/* Grid */
+.grid {
+    display: grid;
+    gap: var(--space-md);
 }
 
 /* Card Grid (for Learning/Projects) */


### PR DESCRIPTION
- Added missing `.grid` class to `css/main.css` to fix stacked items in the Philosophy section.
- Removed `max-width: 800px` from `.hero` container and applied it to `.hero h1` instead. This fixes the misalignment of the hero section relative to the header and other content while maintaining readable line length for the title.
- Verified changes visually using Playwright screenshots.