### PR TITLE
feat: implement terminal design aesthetic across portfolio

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,7 +7,7 @@
     <meta name="description" content="About M S Suchindra Datta Koushik, Software engineer - Backend and Data.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
     <link rel="stylesheet" href="./assets/vendor/oat.min.css">
@@ -18,9 +18,9 @@
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,10 +245,8 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
@@ -220,6 +272,123 @@
         /* Utility overrides */
         .text-muted {
             color: var(--muted-foreground);
+        }
+
+        .browser-top-bar {
+            background-color: #020617;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
+        }
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
+        }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
         }
     </style>
 
@@ -274,24 +443,39 @@
     </style>
 
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="./index.html" class="logo">Suchindra Koushik</a>
+            <a href="./index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="./index.html" class="">Home</a>
-                <a href="./blog/index.html" class="">Writing</a>
-                <a href="./projects.html" class="">Projects</a>
-                <a href="./about.html" class="active">About</a>
-                <a href="./resume.html" class="">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="./index.html" class="">~/home</a>
+                <a href="./projects.html" class="">~/projects</a>
+                <a href="./blog/index.html" class="">~/thoughts</a>
+                <a href="./about.html" class="active">~/about</a>
+                <a href="./resume.html" class="">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container" >
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; ">
 
     <section style="padding-bottom: var(--space-md);">
         <h1>About Me</h1>
@@ -402,16 +586,35 @@ ETL processes drawing near.</p>
 
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
 
 
 </body>
 </html>
+
+    <style data-purpose="cleanup-styles">
+        .hero-section {
+            margin-bottom: 6rem;
+            padding: 2rem 3rem;
+            position: relative;
+            overflow: hidden;
+        }
+    </style>

--- a/blog/batch-data-pipelines.html
+++ b/blog/batch-data-pipelines.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Designing maintainable batch processing systems with idempotency, error handling, and monitoring.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
     <link rel="stylesheet" href="../assets/vendor/oat.min.css">
@@ -18,9 +18,9 @@
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,10 +245,8 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
@@ -221,29 +273,161 @@
         .text-muted {
             color: var(--muted-foreground);
         }
+
+        .browser-top-bar {
+            background-color: #020617;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
+        }
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
+        }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
+        }
     </style>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
 
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="../index.html" class="logo">Suchindra Koushik</a>
+            <a href="../index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="../index.html" class="">Home</a>
-                <a href="../blog/index.html" class="active">Writing</a>
-                <a href="../projects.html" class="">Projects</a>
-                <a href="../about.html" class="">About</a>
-                <a href="../resume.html" class="">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="../index.html" class="">~/home</a>
+                <a href="../projects.html" class="">~/projects</a>
+                <a href="../blog/index.html" class="active">~/thoughts</a>
+                <a href="../about.html" class="">~/about</a>
+                <a href="../resume.html" class="">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container" >
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; ">
 
     <article style="max-width: 800px; margin: 0 auto; padding: var(--space-xl) 0;">
         <header style="margin-bottom: var(--space-lg);">
@@ -372,14 +556,24 @@ def calculate_daily_revenue(target_date: date):
 
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
 
 
@@ -392,3 +586,12 @@ def calculate_daily_revenue(target_date: date):
 
 </body>
 </html>
+
+    <style data-purpose="cleanup-styles">
+        .hero-section {
+            margin-bottom: 6rem;
+            padding: 2rem 3rem;
+            position: relative;
+            overflow: hidden;
+        }
+    </style>

--- a/blog/index.html
+++ b/blog/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Technical articles and thoughts on backend engineering.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
     <link rel="stylesheet" href="../assets/vendor/oat.min.css">
@@ -18,9 +18,9 @@
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,10 +245,8 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
@@ -221,27 +273,159 @@
         .text-muted {
             color: var(--muted-foreground);
         }
+
+        .browser-top-bar {
+            background-color: #020617;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
+        }
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
+        }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
+        }
     </style>
 
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="../index.html" class="logo">Suchindra Koushik</a>
+            <a href="../index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="../index.html" class="">Home</a>
-                <a href="../blog/index.html" class="active">Writing</a>
-                <a href="../projects.html" class="">Projects</a>
-                <a href="../about.html" class="">About</a>
-                <a href="../resume.html" class="">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="../index.html" class="">~/home</a>
+                <a href="../projects.html" class="">~/projects</a>
+                <a href="../blog/index.html" class="active">~/thoughts</a>
+                <a href="../about.html" class="">~/about</a>
+                <a href="../resume.html" class="">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container" >
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; ">
 
     <div style="padding-top: var(--space-xl); max-width: 800px; margin: 0 auto;">
         <h1>Writing</h1>
@@ -296,14 +480,24 @@
 
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
 
 
@@ -354,3 +548,12 @@
 
 </body>
 </html>
+
+    <style data-purpose="cleanup-styles">
+        .hero-section {
+            margin-bottom: 6rem;
+            padding: 2rem 3rem;
+            position: relative;
+            overflow: hidden;
+        }
+    </style>

--- a/blog/postgres-query-planning.html
+++ b/blog/postgres-query-planning.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Understanding how PostgreSQL's query planner works and how to optimize your queries.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
     <link rel="stylesheet" href="../assets/vendor/oat.min.css">
@@ -18,9 +18,9 @@
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,10 +245,8 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
@@ -221,29 +273,161 @@
         .text-muted {
             color: var(--muted-foreground);
         }
+
+        .browser-top-bar {
+            background-color: #020617;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
+        }
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
+        }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
+        }
     </style>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
 
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="../index.html" class="logo">Suchindra Koushik</a>
+            <a href="../index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="../index.html" class="">Home</a>
-                <a href="../blog/index.html" class="active">Writing</a>
-                <a href="../projects.html" class="">Projects</a>
-                <a href="../about.html" class="">About</a>
-                <a href="../resume.html" class="">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="../index.html" class="">~/home</a>
+                <a href="../projects.html" class="">~/projects</a>
+                <a href="../blog/index.html" class="active">~/thoughts</a>
+                <a href="../about.html" class="">~/about</a>
+                <a href="../resume.html" class="">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container" >
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; ">
 
     <article style="max-width: 800px; margin: 0 auto; padding: var(--space-xl) 0;">
         <header style="margin-bottom: var(--space-lg);">
@@ -411,14 +595,24 @@ Postgres maintains a histogram and most common values (MCV) list for every colum
 
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
 
 
@@ -431,3 +625,12 @@ Postgres maintains a histogram and most common values (MCV) list for every colum
 
 </body>
 </html>
+
+    <style data-purpose="cleanup-styles">
+        .hero-section {
+            margin-bottom: 6rem;
+            padding: 2rem 3rem;
+            position: relative;
+            overflow: hidden;
+        }
+    </style>

--- a/blog/python-performance.html
+++ b/blog/python-performance.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Practical techniques for making Python applications faster without premature optimization.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
     <link rel="stylesheet" href="../assets/vendor/oat.min.css">
@@ -18,9 +18,9 @@
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,10 +245,8 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
@@ -221,29 +273,161 @@
         .text-muted {
             color: var(--muted-foreground);
         }
+
+        .browser-top-bar {
+            background-color: #020617;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
+        }
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
+        }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
+        }
     </style>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
 
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="../index.html" class="logo">Suchindra Koushik</a>
+            <a href="../index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="../index.html" class="">Home</a>
-                <a href="../blog/index.html" class="active">Writing</a>
-                <a href="../projects.html" class="">Projects</a>
-                <a href="../about.html" class="">About</a>
-                <a href="../resume.html" class="">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="../index.html" class="">~/home</a>
+                <a href="../projects.html" class="">~/projects</a>
+                <a href="../blog/index.html" class="active">~/thoughts</a>
+                <a href="../about.html" class="">~/about</a>
+                <a href="../resume.html" class="">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container" >
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; ">
 
     <article style="max-width: 800px; margin: 0 auto; padding: var(--space-xl) 0;">
         <header style="margin-bottom: var(--space-lg);">
@@ -362,14 +546,24 @@ def serialize(data):
 
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
 
 
@@ -382,3 +576,12 @@ def serialize(data):
 
 </body>
 </html>
+
+    <style data-purpose="cleanup-styles">
+        .hero-section {
+            margin-bottom: 6rem;
+            padding: 2rem 3rem;
+            position: relative;
+            overflow: hidden;
+        }
+    </style>

--- a/index.html
+++ b/index.html
@@ -3,24 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
-    <title>Suchindra Koushik | Software Engineer - Data and Backend</title>
-    <meta name="description" content="Portfolio of M S Suchindra Datta Koushik, a Software Engineer focused on reliable systems, performance, and clarity.">
+    <title> | Suchindra Koushik</title>
+    <meta name="description" content="">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
-    <link rel="stylesheet" href="assets/vendor/oat.min.css">
-    <script src="assets/vendor/oat.min.js" defer></script>
+    <link rel="stylesheet" href="/assets/vendor/oat.min.css">
+    <script src="/assets/vendor/oat.min.js" defer></script>
 
-    <script src="assets/js/theme.js"></script>
+    <script src="/assets/js/theme.js"></script>
 
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,14 +245,16 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
             line-height: 1.7;
+        }
+
+        code, pre {
+            font-family: var(--font-mono);
         }
 
         /* Grid Utility */
@@ -213,116 +269,318 @@
             }
         }
 
+        /* Utility overrides */
         .text-muted {
             color: var(--muted-foreground);
         }
+
+        .browser-top-bar {
+            background-color: #020617;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
+        }
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
+        }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
+        }
     </style>
+
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="index.html" class="logo">Suchindra Koushik</a>
+            <a href="/index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="index.html" class="active">Home</a>
-                <a href="blog/index.html">Writing</a>
-                <a href="projects.html">Projects</a>
-                <a href="about.html">About</a>
-                <a href="resume.html">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="/index.html" class="">~/home</a>
+                <a href="/projects.html" class="">~/projects</a>
+                <a href="/blog/index.html" class="">~/thoughts</a>
+                <a href="/about.html" class="">~/about</a>
+                <a href="/resume.html" class="">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container">
-        <section style="padding: var(--space-xl) 0; max-width: 800px;">
-            <h1 style="font-size: 2.5rem; line-height: 1.2; margin-bottom: var(--space-md);">Building boring systems that scale.</h1>
-            <p style="font-size: 1.25rem; color: var(--muted-foreground); margin-bottom: var(--space-md);">
-                Specializing in idempotent pipelines, distributed consensus, and code that lets you sleep at night.
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; ">
+
+    <!-- BEGIN: Hero Section -->
+    <section class="terminal-window hero-section" >
+        <!-- Traffic lights -->
+        <div style="display: flex; gap: 0.5rem; position: absolute; top: 1rem; left: 1rem;">
+            <div style="width: 0.75rem; height: 0.75rem; border-radius: 50%; background-color: #ef4444;"></div>
+            <div style="width: 0.75rem; height: 0.75rem; border-radius: 50%; background-color: #eab308;"></div>
+            <div style="width: 0.75rem; height: 0.75rem; border-radius: 50%; background-color: #22c55e;"></div>
+        </div>
+        <div style="margin-top: 2rem; position: relative; z-index: 10;">
+            <h1 style="font-family: var(--font-serif); font-size: 3.5rem; font-weight: 700; line-height: 1.1; margin-bottom: 1.5rem; letter-spacing: -0.025em;">
+                Building boring systems<br/>that scale.
+            </h1>
+            <p style="font-size: 1.125rem; color: var(--muted-foreground); max-width: 48rem; margin-bottom: 2.5rem; line-height: 1.625;">
+                Senior Backend &amp; Data Engineer specializing in idempotent pipelines, distributed consensus, and high-reliability infrastructure that lets you sleep at night.
             </p>
-            <div style="color: var(--muted-foreground); font-family: var(--font-mono); font-size: 0.875rem;">
-                <span>Python</span>
-                <span>•</span>
-                <span>SQL</span>
-                <span>•</span>
-                <span>Distributed Systems</span>
+            <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; font-family: var(--font-mono); font-size: 0.875rem; color: #9ca3af;">
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ Python ]</span>
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ SQL ]</span>
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ Go ]</span>
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ Kubernetes ]</span>
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ Apache Beam ]</span>
             </div>
-        </section>
+        </div>
+    </section>
+    <!-- END: Hero Section -->
 
-        <section style="padding: var(--space-xl) 0;">
-            <h2 style="margin-bottom: var(--space-md);">Engineering Principles</h2>
-            <div class="row">
-                <div class="col-4">
-                    <h3>Systems Thinking</h3>
-                    <p>Software doesn't exist in a vacuum. I design with the entire lifecycle in mind—from observability to maintenance and failure modes.</p>
+    <!-- BEGIN: Engineering Principles -->
+    <section style="margin-bottom: 6rem;">
+        <h2 style="font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700; margin-bottom: 2rem; border-bottom: 1px solid var(--border); padding-bottom: 1rem;">Engineering Principles</h2>
+
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); position: relative;">
+
+            <div style="padding: 2rem; border-bottom: 1px solid var(--border); border-right: 1px solid var(--border); box-sizing: border-box;" class="principle-cell">
+                <h3 style="font-family: var(--font-serif); font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Systems Thinking</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Every component is part of a larger ecosystem. Designing for observability, resilience, and graceful failure from day one, not as an afterthought.
+                </p>
+            </div>
+
+            <div style="padding: 2rem; border-bottom: 1px solid var(--border); border-right: 1px solid var(--border); box-sizing: border-box;" class="principle-cell">
+                <h3 style="font-family: var(--font-serif); font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Data Reliability</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Correctness is paramount. Building idempotent pipelines with strong consistency guarantees, ensuring data integrity across distributed systems.
+                </p>
+            </div>
+
+            <div style="padding: 2rem; border-bottom: 1px solid var(--border); box-sizing: border-box;" class="principle-cell-last">
+                <h3 style="font-family: var(--font-serif); font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Performance</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Optimization is a discipline, not magic. Understanding the full stack, from network protocols to database internals, to eliminate bottlenecks.
+                </p>
+            </div>
+
+            <style>
+                @media (min-width: 768px) {
+                    .principle-cell { border-bottom: none !important; }
+                    .principle-cell-last { border-bottom: none !important; }
+                }
+            </style>
+        </div>
+    </section>
+    <!-- END: Engineering Principles -->
+
+    <!-- BEGIN: Featured Projects -->
+    <section style="margin-bottom: 6rem;">
+        <h2 style="font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700; margin-bottom: 2rem;">Featured Projects</h2>
+
+        <div class="grid-2-col">
+            <!-- Project 1 -->
+            <div class="card-border-glow" style="padding: 2rem; border-radius: 0.5rem; display: flex; flex-direction: column; height: 100%;">
+                <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; margin-bottom: 1rem;">Idempotent Event Processor</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin-bottom: 2rem; flex-grow: 1;">
+                    A high-throughput, distributed event processing system built with Go and Kafka, handling billions of events daily with guaranteed exactly-once semantics.
+                </p>
+                <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-top: auto;">
+                    <span>[ Go ]</span>
+                    <span>[ Kafka ]</span>
+                    <span>[ Docker ]</span>
                 </div>
-                <div class="col-4">
-                    <h3>Data Reliability</h3>
-                    <p>In data engineering, correctness is paramount. I build pipelines that are idempotent, testable, and resilient to change.</p>
+            </div>
+
+            <!-- Project 2 -->
+            <div class="card-border-glow" style="padding: 2rem; border-radius: 0.5rem; display: flex; flex-direction: column; height: 100%;">
+                <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; margin-bottom: 1rem;">Distributed Consensus Engine</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin-bottom: 2rem; flex-grow: 1;">
+                    Implemented a simplified Raft consensus algorithm in Python for a distributed key-value store, focusing on leader election and log replication.
+                </p>
+                <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-top: auto;">
+                    <span>[ Python ]</span>
+                    <span>[ gRPC ]</span>
+                    <span>[ Redis ]</span>
                 </div>
-                <div class="col-4">
-                    <h3>Performance</h3>
-                    <p>Optimization isn't magic. It's understanding the machine, the database, and the network. I dig deep to find the bottlenecks.</p>
-                </div>
             </div>
-        </section>
+        </div>
+    </section>
+    <!-- END: Featured Projects -->
 
-        <section style="padding: var(--space-xl) 0;">
-            <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-md);">
-                <h2>Selected Writing</h2>
-                <a href="blog/index.html" class="text-muted" style="font-size: 0.875rem;">View all &rarr;</a>
-            </div>
+    <!-- BEGIN: Latest Thoughts -->
+    <section style="margin-bottom: 6rem;">
+        <h2 style="font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700; margin-bottom: 2rem;">Latest Thoughts</h2>
 
-            <div class="grid-2-col">
-                <!-- Featured Post 1 -->
-                <article class="card">
-                    <header>
-                        <div class="text-muted" style="font-size: 0.75rem;">Data Engineering</div>
-                        <h3><a href="blog/postgres-query-planning.html" style="text-decoration: none; color: inherit;">How PostgreSQL Query Planning Actually Works</a></h3>
-                    </header>
-                    <p style="font-size: 0.875rem;">Understanding the optimizer is the first step to writing high-performance SQL. Let's dive into cost models and access methods.</p>
-                    <footer>
-                            <a href="blog/postgres-query-planning.html" class="button small outline">Read article</a>
-                    </footer>
-                </article>
+        <div class="grid-2-col">
+            <!-- Article 1 -->
+            <a href="blog/postgres-query-planning.html" class="card-border-glow" style="display: block; padding: 2rem; border-radius: 0.5rem; text-decoration: none; display: flex; flex-direction: column; height: 100%;">
+                <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; color: var(--foreground); transition: color 0.2s;" onmouseover="this.style.color='var(--terminal-green)'" onmouseout="this.style.color='var(--foreground)'">How Postgres Query Planning Actually Works</h3>
+                <div style="font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-bottom: 1rem;">Oct 26, 2024</div>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Understanding the optimizer's cost models is critical for writing high-performance queries. We dive deep into access methods and index utilization.
+                </p>
+            </a>
 
-                <!-- Featured Post 2 -->
-                <article class="card">
-                    <header>
-                        <div class="text-muted" style="font-size: 0.75rem;">Architecture</div>
-                        <h3><a href="blog/batch-data-pipelines.html" style="text-decoration: none; color: inherit;">Designing Reliable Batch Data Pipelines</a></h3>
-                    </header>
-                    <p style="font-size: 0.875rem;">Why "retry until success" isn't a strategy. Patterns for building robust ETL systems that sleep well at night.</p>
-                    <footer>
-                            <a href="blog/batch-data-pipelines.html" class="button small outline">Read article</a>
-                    </footer>
-                </article>
+            <!-- Article 2 -->
+            <a href="blog/batch-data-pipelines.html" class="card-border-glow" style="display: block; padding: 2rem; border-radius: 0.5rem; text-decoration: none; display: flex; flex-direction: column; height: 100%;">
+                <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; color: var(--foreground); transition: color 0.2s;" onmouseover="this.style.color='var(--terminal-green)'" onmouseout="this.style.color='var(--foreground)'">Designing Reliable Batch Data Pipelines</h3>
+                <div style="font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-bottom: 1rem;">Sep 14, 2024</div>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Why "retry until success" is not a strategy. Exploring patterns for building robust, recoverable ETL workflows that don't wake you up at 3 AM.
+                </p>
+            </a>
+        </div>
+    </section>
+    <!-- END: Latest Thoughts -->
 
-                <!-- Featured Post 3 -->
-                <article class="card">
-                        <header>
-                        <div class="text-muted" style="font-size: 0.75rem;">Python</div>
-                        <h3><a href="blog/python-performance.html" style="text-decoration: none; color: inherit;">Python Performance: Where It Breaks and Why</a></h3>
-                    </header>
-                    <p style="font-size: 0.875rem;">Python is slow, but your code doesn't have to be. Examining the GIL, memory management, and when to drop to C.</p>
-                    <footer>
-                            <a href="blog/python-performance.html" class="button small outline">Read article</a>
-                    </footer>
-                </article>
-            </div>
-        </section>
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
+
 
 </body>
 </html>
+
+    <style data-purpose="cleanup-styles">
+        .hero-section {
+            margin-bottom: 6rem;
+            padding: 2rem 3rem;
+            position: relative;
+            overflow: hidden;
+        }
+    </style>

--- a/projects.html
+++ b/projects.html
@@ -4,23 +4,23 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
     <title>Projects | Suchindra Koushik</title>
-    <meta name="description" content="Software projects and open source contributions by Suchindra Koushik.">
+    <meta name="description" content="Suchindra Koushik - Portfolio">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
-    <link rel="stylesheet" href="assets/vendor/oat.min.css">
-    <script src="assets/vendor/oat.min.js" defer></script>
+    <link rel="stylesheet" href="./assets/vendor/oat.min.css">
+    <script src="./assets/vendor/oat.min.js" defer></script>
 
-    <script src="assets/js/theme.js"></script>
+    <script src="./assets/js/theme.js"></script>
 
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,123 +245,286 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
             line-height: 1.7;
         }
 
+        code, pre {
+            font-family: var(--font-mono);
+        }
+
+        /* Grid Utility */
+        .grid-2-col {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: var(--space-md);
+        }
+        @media (min-width: 768px) {
+            .grid-2-col {
+                grid-template-columns: 1fr 1fr;
+            }
+        }
+
         /* Utility overrides */
         .text-muted {
             color: var(--muted-foreground);
         }
+
+        .browser-top-bar {
+            background-color: #020617;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
+        }
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
+        }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
+        }
     </style>
+
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="index.html" class="logo">Suchindra Koushik</a>
+            <a href="./index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="index.html">Home</a>
-                <a href="blog/index.html">Writing</a>
-                <a href="projects.html" class="active">Projects</a>
-                <a href="about.html">About</a>
-                <a href="resume.html">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="./index.html" class="">~/home</a>
+                <a href="./projects.html" class="active">~/projects</a>
+                <a href="./blog/index.html" class="">~/thoughts</a>
+                <a href="./about.html" class="">~/about</a>
+                <a href="./resume.html" class="">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container" style="padding-top: var(--space-xl); max-width: 900px;">
-        <h1>Projects</h1>
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; padding-top: var(--space-xl);">
+        <h1 style="font-family: var(--font-serif); font-size: 2.5rem; font-weight: 700; margin-bottom: 1rem;">Projects</h1>
         <p class="text-muted" style="margin-bottom: var(--space-xl);">
             Open source tools, system experiments, and other things I've built.
         </p>
 
-        <div class="row" style="row-gap: var(--space-md);">
+        <div class="row" style="row-gap: var(--space-md); display: flex; flex-wrap: wrap;">
 
             <!-- Project 1 -->
-            <div class="col-6">
-                <article class="card" style="height: 100%;">
-                    <header>
-                        <div class="text-muted" style="font-size: 0.75rem;">Go • Distributed Systems</div>
-                        <h3>Distributed KV Store</h3>
+            <div class="col-6" style="padding: 0 0.75rem; box-sizing: border-box; width: 50%;">
+                <article class="card-border-glow" style="height: 100%; padding: 2rem; border-radius: 0.5rem; display: flex; flex-direction: column;">
+                    <header style="margin-bottom: 1rem;">
+                        <div style="font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-bottom: 0.5rem;">[ Go ] [ Distributed Systems ]</div>
+                        <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; color: var(--foreground);">Distributed KV Store</h3>
                     </header>
-                    <p>
+                    <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin-bottom: 2rem; flex-grow: 1;">
                         A distributed key-value store implementing Raft for consensus. Features strong consistency, leader election, and log replication.
                     </p>
-                    <footer>
-                        <a href="https://github.com/dattskoushik" target="_blank" class="button small outline">View Code &rarr;</a>
+                    <footer style="margin-top: auto;">
+                        <a href="https://github.com/dattskoushik" target="_blank" class="button small outline" style="font-family: var(--font-mono); text-decoration: none; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 0.25rem; color: var(--foreground); display: inline-block;">View Code &rarr;</a>
                     </footer>
                 </article>
             </div>
 
             <!-- Project 2 -->
-            <div class="col-6">
-                <article class="card" style="height: 100%;">
-                    <header>
-                        <div class="text-muted" style="font-size: 0.75rem;">Python • Data Engineering</div>
-                        <h3>TinyETL</h3>
+            <div class="col-6" style="padding: 0 0.75rem; box-sizing: border-box; width: 50%;">
+                <article class="card-border-glow" style="height: 100%; padding: 2rem; border-radius: 0.5rem; display: flex; flex-direction: column;">
+                    <header style="margin-bottom: 1rem;">
+                        <div style="font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-bottom: 0.5rem;">[ Python ] [ Data Engineering ]</div>
+                        <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; color: var(--foreground);">TinyETL</h3>
                     </header>
-                    <p>
+                    <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin-bottom: 2rem; flex-grow: 1;">
                         A lightweight, configuration-driven ETL framework for small to medium scale data pipelines. Supports idempotent retries and pluggable backends.
                     </p>
-                    <footer>
-                        <a href="https://github.com/dattskoushik" target="_blank" class="button small outline">View Code &rarr;</a>
+                    <footer style="margin-top: auto;">
+                        <a href="https://github.com/dattskoushik" target="_blank" class="button small outline" style="font-family: var(--font-mono); text-decoration: none; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 0.25rem; color: var(--foreground); display: inline-block;">View Code &rarr;</a>
                     </footer>
                 </article>
             </div>
 
             <!-- Project 3 -->
-            <div class="col-6">
-                <article class="card" style="height: 100%;">
-                    <header>
-                        <div class="text-muted" style="font-size: 0.75rem;">Rust • CLI</div>
-                        <h3>LogParser CLI</h3>
+            <div class="col-6" style="padding: 0 0.75rem; box-sizing: border-box; width: 50%; margin-top: 1.5rem;">
+                <article class="card-border-glow" style="height: 100%; padding: 2rem; border-radius: 0.5rem; display: flex; flex-direction: column;">
+                    <header style="margin-bottom: 1rem;">
+                        <div style="font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-bottom: 0.5rem;">[ Rust ] [ CLI ]</div>
+                        <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; color: var(--foreground);">LogParser CLI</h3>
                     </header>
-                    <p>
+                    <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin-bottom: 2rem; flex-grow: 1;">
                         A blazing fast log analysis tool written in Rust. Parses gigabytes of logs in seconds and supports SQL-like querying capabilities.
                     </p>
-                    <footer>
-                        <a href="https://github.com/dattskoushik" target="_blank" class="button small outline">View Code &rarr;</a>
+                    <footer style="margin-top: auto;">
+                        <a href="https://github.com/dattskoushik" target="_blank" class="button small outline" style="font-family: var(--font-mono); text-decoration: none; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 0.25rem; color: var(--foreground); display: inline-block;">View Code &rarr;</a>
                     </footer>
                 </article>
             </div>
 
             <!-- Project 4 -->
-            <div class="col-6">
-                <article class="card" style="height: 100%;">
-                    <header>
-                        <div class="text-muted" style="font-size: 0.75rem;">PostgreSQL • Performance</div>
-                        <h3>PG-Stats-Monitor</h3>
+            <div class="col-6" style="padding: 0 0.75rem; box-sizing: border-box; width: 50%; margin-top: 1.5rem;">
+                <article class="card-border-glow" style="height: 100%; padding: 2rem; border-radius: 0.5rem; display: flex; flex-direction: column;">
+                    <header style="margin-bottom: 1rem;">
+                        <div style="font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-bottom: 0.5rem;">[ PostgreSQL ] [ Performance ]</div>
+                        <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; color: var(--foreground);">PG-Stats-Monitor</h3>
                     </header>
-                    <p>
+                    <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin-bottom: 2rem; flex-grow: 1;">
                         A dashboard for visualizing PostgreSQL internal statistics, lock contention, and query performance metrics in real-time.
                     </p>
-                    <footer>
-                        <a href="https://github.com/dattskoushik" target="_blank" class="button small outline">View Code &rarr;</a>
+                    <footer style="margin-top: auto;">
+                        <a href="https://github.com/dattskoushik" target="_blank" class="button small outline" style="font-family: var(--font-mono); text-decoration: none; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 0.25rem; color: var(--foreground); display: inline-block;">View Code &rarr;</a>
                     </footer>
                 </article>
             </div>
 
+            <style>
+                @media (max-width: 768px) {
+                    .col-6 { width: 100% !important; margin-top: 1.5rem !important; }
+                    .col-6:first-child { margin-top: 0 !important; }
+                }
+            </style>
         </div>
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+<footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
-
 </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -4,23 +4,23 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
     <title>Resume | Suchindra Koushik</title>
-    <meta name="description" content="Resume of M S Suchindra Datta Koushik, Software Engineer - Data and Backend.">
+    <meta name="description" content="Suchindra Koushik - Portfolio">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
-    <link rel="stylesheet" href="assets/vendor/oat.min.css">
-    <script src="assets/vendor/oat.min.js" defer></script>
+    <link rel="stylesheet" href="./assets/vendor/oat.min.css">
+    <script src="./assets/vendor/oat.min.js" defer></script>
 
-    <script src="assets/js/theme.js"></script>
+    <script src="./assets/js/theme.js"></script>
 
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,14 +245,28 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
             line-height: 1.7;
+        }
+
+        code, pre {
+            font-family: var(--font-mono);
+        }
+
+        /* Grid Utility */
+        .grid-2-col {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: var(--space-md);
+        }
+        @media (min-width: 768px) {
+            .grid-2-col {
+                grid-template-columns: 1fr 1fr;
+            }
         }
 
         /* Utility overrides */
@@ -206,138 +274,160 @@
             color: var(--muted-foreground);
         }
 
-        /* Resume Specific Styles */
-        .resume-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            margin-bottom: var(--space-lg);
+        .browser-top-bar {
+            background-color: #020617;
             border-bottom: 1px solid var(--border);
-            padding-bottom: var(--space-md);
-        }
-        .resume-header h1 {
-            font-size: 2.5rem;
-            margin-bottom: var(--space-xs);
-        }
-        .resume-role {
-            font-size: 1.25rem;
-            color: var(--muted-foreground);
-            margin-bottom: var(--space-sm);
-        }
-        .resume-contact {
-            font-family: var(--font-mono);
-            font-size: 0.875rem;
-            color: var(--muted-foreground);
             display: flex;
-            gap: var(--space-md);
-            flex-wrap: wrap;
-        }
-        .resume-section {
-            margin-bottom: var(--space-xl);
-        }
-        .resume-section h2 {
-            font-size: 1rem;
-            text-transform: uppercase;
-            letter-spacing: 0.1em;
-            color: var(--muted-foreground);
-            margin-bottom: var(--space-md);
-            border-bottom: 1px solid var(--border);
-            padding-bottom: var(--space-xs);
-            display: inline-block;
-        }
-        .experience-item {
-            margin-bottom: var(--space-lg);
-        }
-        .experience-header {
-            display: flex;
-            justify-content: space-between;
-            margin-bottom: var(--space-xs);
-            align-items: baseline;
-        }
-        .experience-header h3 {
-            font-size: 1.125rem;
-            font-weight: 600;
-            color: var(--foreground);
-        }
-        .company {
-            color: var(--muted-foreground);
-            font-weight: 400;
-        }
-        .date {
-            font-family: var(--font-mono);
-            font-size: 0.875rem;
-            color: var(--muted-foreground);
-        }
-        .experience-details {
-            list-style-type: disc;
-            padding-left: var(--space-md);
-            color: var(--foreground);
-        }
-        .experience-details li {
-            margin-bottom: 0.5rem;
-        }
-        .skills-grid {
-            display: grid;
-            grid-template-columns: 150px 1fr;
-            gap: var(--space-md);
-            margin-bottom: var(--space-md);
-        }
-        .skill-category {
-            font-weight: 600;
-            color: var(--muted-foreground);
-        }
-        .skill-list {
-            color: var(--foreground);
-        }
-        .btn-download {
-            display: inline-flex;
             align-items: center;
-            gap: var(--space-xs);
-            background: var(--foreground);
-            color: var(--background);
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
             padding: 0.5rem 1rem;
-            border-radius: var(--radius-sm); /* Using custom var, but Oat has utility classes. I kept vars. */
-            text-decoration: none;
-            font-weight: 500;
-            transition: opacity 0.2s ease;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
         }
-        .btn-download:hover {
-            opacity: 0.9;
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
         }
-        @media (max-width: 768px) {
-            .resume-header {
-                flex-direction: column;
-                gap: var(--space-md);
-            }
-            .experience-header {
-                flex-direction: column;
-                gap: 0;
-            }
-            .skills-grid {
-                grid-template-columns: 1fr;
-                gap: var(--space-xs);
-            }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
         }
     </style>
+
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="index.html" class="logo">Suchindra Koushik</a>
+            <a href="./index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="index.html">Home</a>
-                <a href="blog/index.html">Writing</a>
-                <a href="projects.html">Projects</a>
-                <a href="about.html">About</a>
-                <a href="resume.html" class="active">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="./index.html" class="">~/home</a>
+                <a href="./projects.html" class="">~/projects</a>
+                <a href="./blog/index.html" class="">~/thoughts</a>
+                <a href="./about.html" class="">~/about</a>
+                <a href="./resume.html" class="active">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container" style="padding-top: var(--space-xl); max-width: 900px;">
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; padding-top: var(--space-xl);">
+
 
         <div class="resume-header">
             <div>
@@ -423,17 +513,27 @@
             </div>
         </div>
 
+
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+<footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
-
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <meta name="description" content="{{ description }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Mono:wght@400;500&family=Roboto+Slab:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Zilla+Slab:wght@600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
 
     <!-- Oat UI -->
     <link rel="stylesheet" href="{{ root }}/assets/vendor/oat.min.css">
@@ -18,9 +18,9 @@
     <style>
         :root {
             /* Fonts */
-            --font-serif: 'Roboto Slab', serif;
+            --font-serif: 'Zilla Slab', serif;
             --font-sans: 'Inter', sans-serif;
-            --font-mono: 'Roboto Mono', monospace;
+            --font-mono: 'Fira Code', monospace;
 
             /* Spacing overrides if needed */
             --space-xl: 4rem;
@@ -31,46 +31,48 @@
 
         /* Dark Theme (Default) */
         [data-theme="dark"] {
-            --background: #0a0a0a;
-            --foreground: #ededed;
-            --card: #111111;
-            --card-foreground: #ededed;
-            --muted: #1f1f23;
-            --muted-foreground: #a1a1aa;
-            --border: #27272a;
-            --primary: #ffffff;
-            --primary-foreground: #000000;
-            --secondary: #1f1f23;
-            --secondary-foreground: #ededed;
-            --accent: #ffffff;
-            --accent-foreground: #000000;
-            --ring: #27272a;
-            --input: #1f1f23;
+            --background: #0f172a;
+            --foreground: #d1d5db;
+            --card: #1e293b;
+            --card-foreground: #d1d5db;
+            --muted: #1e293b;
+            --muted-foreground: #9ca3af;
+            --border: #334155;
+            --primary: #4ade80;
+            --primary-foreground: #0f172a;
+            --secondary: #1e293b;
+            --secondary-foreground: #d1d5db;
+            --accent: #4ade80;
+            --accent-foreground: #0f172a;
+            --ring: #4ade80;
+            --input: #1e293b;
             /* Custom */
-            --header-bg: rgba(10, 10, 10, 0.8);
-            --code-bg: #1f1f23;
+            --header-bg: #0f172a;
+            --code-bg: #1e293b;
+            --terminal-green: #4ade80;
         }
 
         /* Light Theme */
         [data-theme="light"] {
-            --background: #f4f4f5;
-            --foreground: #18181b;
+            --background: #f8fafc;
+            --foreground: #334155;
             --card: #ffffff;
-            --card-foreground: #18181b;
-            --muted: #e4e4e7;
-            --muted-foreground: #52525b;
-            --border: #e4e4e7;
-            --primary: #000000;
+            --card-foreground: #334155;
+            --muted: #f1f5f9;
+            --muted-foreground: #64748b;
+            --border: #e2e8f0;
+            --primary: #10b981;
             --primary-foreground: #ffffff;
-            --secondary: #e4e4e7;
-            --secondary-foreground: #18181b;
-            --accent: #000000;
+            --secondary: #f1f5f9;
+            --secondary-foreground: #334155;
+            --accent: #10b981;
             --accent-foreground: #ffffff;
-            --ring: #e4e4e7;
+            --ring: #10b981;
             --input: #ffffff;
             /* Custom */
-            --header-bg: rgba(244, 244, 245, 0.8);
-            --code-bg: #e4e4e7;
+            --header-bg: #f8fafc;
+            --code-bg: #f1f5f9;
+            --terminal-green: #10b981;
         }
 
         body {
@@ -85,38 +87,69 @@
             top: 0;
             z-index: 50;
             background-color: var(--header-bg);
-            backdrop-filter: blur(8px);
             border-bottom: 1px solid var(--border);
-            padding: var(--space-sm) 0;
+            padding: 1rem 0;
         }
 
         header .container {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            max-width: 1152px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
         }
 
         .logo {
             font-weight: 700;
             text-decoration: none;
-            color: var(--foreground);
+            color: #ffffff;
+            font-family: var(--font-mono);
+            font-size: 1.125rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        [data-theme="light"] .logo {
+            color: #000000;
+        }
+
+        .logo-prefix {
+            color: var(--terminal-green);
         }
 
         nav.nav-links {
             display: flex;
             gap: var(--space-md);
             align-items: center;
+            font-family: var(--font-mono);
+            font-size: 0.875rem;
+            text-transform: none;
+            letter-spacing: normal;
         }
 
         nav.nav-links a {
             text-decoration: none;
-            color: var(--muted-foreground);
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-        nav.nav-links a:hover, nav.nav-links a.active {
             color: var(--foreground);
+            transition: color 0.2s;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
+        nav.nav-links a:hover {
+            color: var(--terminal-green);
+        }
+
+        nav.nav-links a.active {
+            background-color: rgba(74, 222, 128, 0.2);
+            color: var(--terminal-green);
+        }
+
+        [data-theme="light"] nav.nav-links a.active {
+            background-color: rgba(16, 185, 129, 0.2);
         }
 
         /* Mobile Menu */
@@ -153,22 +186,43 @@
 
         /* Footer */
         .site-footer {
-            margin-top: var(--space-xl);
-            padding: var(--space-lg) 0;
+            margin-top: auto;
+            padding: 2rem 0;
             border-top: 1px solid var(--border);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+            background-color: var(--background);
             color: var(--muted-foreground);
-            font-size: 0.875rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            width: 100%;
         }
-        .social-links {
+
+        .site-footer .container {
+            max-width: 1024px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
             display: flex;
-            gap: var(--space-sm);
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .footer-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .footer-success {
+            color: var(--terminal-green);
+        }
+
+        .social-links {
+            display: inline-flex;
+            gap: 0.5rem;
         }
         .social-links a {
             color: var(--muted-foreground);
             text-decoration: none;
+            transition: color 0.2s;
         }
         .social-links a:hover {
             color: var(--foreground);
@@ -191,10 +245,8 @@
             color: var(--foreground);
         }
 
-        nav.nav-links a, .button, button {
+        .button, button {
             font-family: var(--font-mono);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
         }
 
         body {
@@ -221,40 +273,191 @@
         .text-muted {
             color: var(--muted-foreground);
         }
+
+        .browser-top-bar {
+            background-color: #020617;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+            height: 2.5rem;
+            font-size: 0.75rem;
+            font-family: var(--font-mono);
+            color: #9ca3af;
+            user-select: none;
+        }
+
+        [data-theme="light"] .browser-top-bar {
+            background-color: #e2e8f0;
+            color: #64748b;
+        }
+
+        .browser-tab {
+            background-color: var(--card);
+            padding: 0.5rem 1rem;
+            border-radius: 0.375rem 0.375rem 0 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-top: 1px solid var(--border);
+            border-left: 1px solid var(--border);
+            border-right: 1px solid var(--border);
+            border-bottom: 1px solid transparent;
+            position: relative;
+            top: 1px;
+        }
+
+        .browser-tab-close {
+            color: #6b7280;
+            cursor: pointer;
+        }
+        .browser-tab-close:hover {
+            color: #d1d5db;
+        }
+
+        .browser-add {
+            padding: 0 0.75rem;
+            cursor: pointer;
+        }
+        .browser-add:hover {
+            color: #d1d5db;
+        }
+
+        /* Custom scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #020617;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-track {
+            background: #f1f5f9;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155;
+            border-radius: 4px;
+        }
+        [data-theme="light"] ::-webkit-scrollbar-thumb {
+            background: #cbd5e1;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: var(--terminal-green);
+        }
+
+        /* Terminal Window Global Utility */
+        .terminal-window {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            background: var(--card);
+            border-radius: 8px;
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            position: relative;
+        }
+        [data-theme="light"] .terminal-window {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .terminal-window::before {
+            content: '';
+            position: absolute;
+            top: -1px; left: -1px; right: -1px; bottom: -1px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, rgba(74, 222, 128, 0.4) 0%, rgba(74, 222, 128, 0) 100%);
+            z-index: -1;
+            opacity: 0.5;
+        }
+        [data-theme="light"] .terminal-window::before {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.4) 0%, rgba(16, 185, 129, 0) 100%);
+        }
+
+        .card-border-glow {
+            border: 1px solid rgba(74, 222, 128, 0.4);
+            box-shadow: 0 0 15px 2px rgba(74, 222, 128, 0.2), inset 0 0 10px rgba(74, 222, 128, 0.1);
+            transition: all 0.3s ease;
+            background: var(--card);
+        }
+        [data-theme="light"] .card-border-glow {
+            border-color: rgba(16, 185, 129, 0.4);
+            box-shadow: 0 0 15px 2px rgba(16, 185, 129, 0.1), inset 0 0 10px rgba(16, 185, 129, 0.05);
+        }
+
+        .card-border-glow:hover {
+            border-color: rgba(74, 222, 128, 0.8);
+            box-shadow: 0 0 25px 4px rgba(74, 222, 128, 0.3), inset 0 0 15px rgba(74, 222, 128, 0.2);
+            transform: translateY(-2px);
+        }
+        [data-theme="light"] .card-border-glow:hover {
+            border-color: rgba(16, 185, 129, 0.8);
+            box-shadow: 0 0 25px 4px rgba(16, 185, 129, 0.2), inset 0 0 15px rgba(16, 185, 129, 0.1);
+        }
     </style>
     {% block head_extra %}{% endblock %}
 </head>
-<body data-theme="dark">
+<body data-theme="dark" style="display: flex; flex-direction: column; min-height: 100vh;">
+
+    <!-- BEGIN: Browser Top Bar (Decorative) -->
+    <div class="browser-top-bar">
+        <div class="browser-tab">
+            <span>Suchindra Koushik</span>
+            <span class="browser-tab-close">×</span>
+        </div>
+        <div class="browser-add">+</div>
+    </div>
+    <!-- END: Browser Top Bar -->
 
     <header class="site-header">
         <div class="container">
-            <a href="{{ root }}/index.html" class="logo">Suchindra Koushik</a>
+            <a href="{{ root }}/index.html" class="logo">
+                <span class="logo-prefix">&gt;_</span>
+                <span>Suchindra Koushik</span>
+            </a>
             <button class="mobile-menu-btn" aria-label="Toggle menu" aria-expanded="false">☰</button>
             <nav class="nav-links">
-                <a href="{{ root }}/index.html" class="{% if active_page == 'home' %}active{% endif %}">Home</a>
-                <a href="{{ root }}/blog/index.html" class="{% if active_page == 'blog' %}active{% endif %}">Writing</a>
-                <a href="{{ root }}/projects.html" class="{% if active_page == 'projects' %}active{% endif %}">Projects</a>
-                <a href="{{ root }}/about.html" class="{% if active_page == 'about' %}active{% endif %}">About</a>
-                <a href="{{ root }}/resume.html" class="{% if active_page == 'resume' %}active{% endif %}">Resume</a>
-                <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                <a href="{{ root }}/index.html" class="{% if active_page == 'home' %}active{% endif %}">~/home</a>
+                <a href="{{ root }}/projects.html" class="{% if active_page == 'projects' %}active{% endif %}">~/projects</a>
+                <a href="{{ root }}/blog/index.html" class="{% if active_page == 'blog' %}active{% endif %}">~/thoughts</a>
+                <a href="{{ root }}/about.html" class="{% if active_page == 'about' %}active{% endif %}">~/about</a>
+                <a href="{{ root }}/resume.html" class="{% if active_page == 'resume' %}active{% endif %}">~/resume</a>
+                <div style="display: flex; align-items: center; gap: 0.5rem; margin-left: 1rem; padding-left: 1rem; border-left: 1px solid var(--border);">
+                    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+                </div>
             </nav>
         </div>
     </header>
 
-    <main class="container" {% if main_style %}style="{{ main_style }}"{% endif %}>
+    <main class="container" style="flex-grow: 1; max-width: 1024px; margin: 0 auto; padding: 3rem 1.5rem; {% if main_style %}{{ main_style }}{% endif %}">
         {% block content %}{% endblock %}
     </main>
 
-    <footer class="site-footer container">
-        <div class="social-links">
-            <a href="https://github.com/dattskoushik" target="_blank">GitHub</a>
-            <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">LinkedIn</a>
-            <a href="https://instagram.com/dattskoushik" target="_blank">Instagram</a>
-            <a href="mailto:suchindra.formal@outlook.com">Email</a>
+    <footer class="site-footer">
+        <div class="container">
+            <div class="footer-status">
+                <span class="footer-success">[SUCCESS]</span>
+                <span>Build completed. Status: Deploying to production. | &gt; git commit -m "Update portfolio" |</span>
+            </div>
+            <div>
+                <span>Contact: 'mailto:suchindra.formal@outlook.com' | Links: </span>
+                <span class="social-links">
+                    <a href="https://github.com/dattskoushik" target="_blank">[GitHub]</a>,
+                    <a href="https://linkedin.com/in/suchindrakoushik" target="_blank">[LinkedIn]</a>,
+                    <a href="https://instagram.com/dattskoushik" target="_blank">[Instagram]</a>
+                </span> |
+            </div>
+            <div>
+                <span>&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved. [Build ID: 8a7f4e]</span>
+            </div>
         </div>
-        <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Suchindra Koushik. All rights reserved.</p>
     </footer>
 
     {% block footer_scripts %}{% endblock %}
 </body>
 </html>
+
+    <style data-purpose="cleanup-styles">
+        .hero-section {
+            margin-bottom: 6rem;
+            padding: 2rem 3rem;
+            position: relative;
+            overflow: hidden;
+        }
+    </style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,86 +1,126 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <!--
-        NOTE: This template is prepared for future integration with build_static.py.
-        Currently, the homepage is a static file (index.html) because the build script
-        does not generate the root index. If you update the build script, you can use this template.
-    -->
-
-    <section style="padding: var(--space-xl) 0; max-width: 800px;">
-        <h1 style="font-size: 2.5rem; line-height: 1.2; margin-bottom: var(--space-md);">Building boring systems that scale.</h1>
-        <p style="font-size: 1.25rem; color: var(--muted-foreground); margin-bottom: var(--space-md);">
-            Specializing in idempotent pipelines, distributed consensus, and code that lets you sleep at night.
-        </p>
-        <div style="color: var(--muted-foreground); font-family: var(--font-mono); font-size: 0.875rem;">
-            <span>Python</span>
-            <span>•</span>
-            <span>SQL</span>
-            <span>•</span>
-            <span>Distributed Systems</span>
+    <!-- BEGIN: Hero Section -->
+    <section class="terminal-window hero-section" >
+        <!-- Traffic lights -->
+        <div style="display: flex; gap: 0.5rem; position: absolute; top: 1rem; left: 1rem;">
+            <div style="width: 0.75rem; height: 0.75rem; border-radius: 50%; background-color: #ef4444;"></div>
+            <div style="width: 0.75rem; height: 0.75rem; border-radius: 50%; background-color: #eab308;"></div>
+            <div style="width: 0.75rem; height: 0.75rem; border-radius: 50%; background-color: #22c55e;"></div>
         </div>
-    </section>
-
-    <section style="padding: var(--space-xl) 0;">
-        <h2 style="margin-bottom: var(--space-md);">Engineering Principles</h2>
-        <div class="row">
-            <div class="col-4">
-                <h3>Systems Thinking</h3>
-                <p>Software doesn't exist in a vacuum. I design with the entire lifecycle in mind—from observability to maintenance and failure modes.</p>
-            </div>
-            <div class="col-4">
-                <h3>Data Reliability</h3>
-                <p>In data engineering, correctness is paramount. I build pipelines that are idempotent, testable, and resilient to change.</p>
-            </div>
-            <div class="col-4">
-                <h3>Performance</h3>
-                <p>Optimization isn't magic. It's understanding the machine, the database, and the network. I dig deep to find the bottlenecks.</p>
+        <div style="margin-top: 2rem; position: relative; z-index: 10;">
+            <h1 style="font-family: var(--font-serif); font-size: 3.5rem; font-weight: 700; line-height: 1.1; margin-bottom: 1.5rem; letter-spacing: -0.025em;">
+                Building boring systems<br/>that scale.
+            </h1>
+            <p style="font-size: 1.125rem; color: var(--muted-foreground); max-width: 48rem; margin-bottom: 2.5rem; line-height: 1.625;">
+                Senior Backend &amp; Data Engineer specializing in idempotent pipelines, distributed consensus, and high-reliability infrastructure that lets you sleep at night.
+            </p>
+            <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; font-family: var(--font-mono); font-size: 0.875rem; color: #9ca3af;">
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ Python ]</span>
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ SQL ]</span>
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ Go ]</span>
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ Kubernetes ]</span>
+                <span style="padding: 0.25rem 0.5rem; background-color: rgba(0,0,0,0.2); border: 1px solid var(--border); border-radius: 0.25rem;">[ Apache Beam ]</span>
             </div>
         </div>
     </section>
+    <!-- END: Hero Section -->
 
-    <section style="padding: var(--space-xl) 0;">
-        <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-md);">
-            <h2>Selected Writing</h2>
-            <a href="blog/index.html" class="text-muted" style="font-size: 0.875rem;">View all &rarr;</a>
+    <!-- BEGIN: Engineering Principles -->
+    <section style="margin-bottom: 6rem;">
+        <h2 style="font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700; margin-bottom: 2rem; border-bottom: 1px solid var(--border); padding-bottom: 1rem;">Engineering Principles</h2>
+
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); position: relative;">
+
+            <div style="padding: 2rem; border-bottom: 1px solid var(--border); border-right: 1px solid var(--border); box-sizing: border-box;" class="principle-cell">
+                <h3 style="font-family: var(--font-serif); font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Systems Thinking</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Every component is part of a larger ecosystem. Designing for observability, resilience, and graceful failure from day one, not as an afterthought.
+                </p>
+            </div>
+
+            <div style="padding: 2rem; border-bottom: 1px solid var(--border); border-right: 1px solid var(--border); box-sizing: border-box;" class="principle-cell">
+                <h3 style="font-family: var(--font-serif); font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Data Reliability</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Correctness is paramount. Building idempotent pipelines with strong consistency guarantees, ensuring data integrity across distributed systems.
+                </p>
+            </div>
+
+            <div style="padding: 2rem; border-bottom: 1px solid var(--border); box-sizing: border-box;" class="principle-cell-last">
+                <h3 style="font-family: var(--font-serif); font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Performance</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Optimization is a discipline, not magic. Understanding the full stack, from network protocols to database internals, to eliminate bottlenecks.
+                </p>
+            </div>
+
+            <style>
+                @media (min-width: 768px) {
+                    .principle-cell { border-bottom: none !important; }
+                    .principle-cell-last { border-bottom: none !important; }
+                }
+            </style>
         </div>
+    </section>
+    <!-- END: Engineering Principles -->
+
+    <!-- BEGIN: Featured Projects -->
+    <section style="margin-bottom: 6rem;">
+        <h2 style="font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700; margin-bottom: 2rem;">Featured Projects</h2>
 
         <div class="grid-2-col">
-            <!-- Featured Post 1 -->
-            <article class="card">
-                <header>
-                    <div class="text-muted" style="font-size: 0.75rem;">Data Engineering</div>
-                    <h3><a href="blog/postgres-query-planning.html" style="text-decoration: none; color: inherit;">How PostgreSQL Query Planning Actually Works</a></h3>
-                </header>
-                <p style="font-size: 0.875rem;">Understanding the optimizer is the first step to writing high-performance SQL. Let's dive into cost models and access methods.</p>
-                <footer>
-                        <a href="blog/postgres-query-planning.html" class="button small outline">Read article</a>
-                </footer>
-            </article>
+            <!-- Project 1 -->
+            <div class="card-border-glow" style="padding: 2rem; border-radius: 0.5rem; display: flex; flex-direction: column; height: 100%;">
+                <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; margin-bottom: 1rem;">Idempotent Event Processor</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin-bottom: 2rem; flex-grow: 1;">
+                    A high-throughput, distributed event processing system built with Go and Kafka, handling billions of events daily with guaranteed exactly-once semantics.
+                </p>
+                <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-top: auto;">
+                    <span>[ Go ]</span>
+                    <span>[ Kafka ]</span>
+                    <span>[ Docker ]</span>
+                </div>
+            </div>
 
-            <!-- Featured Post 2 -->
-            <article class="card">
-                <header>
-                    <div class="text-muted" style="font-size: 0.75rem;">Architecture</div>
-                    <h3><a href="blog/batch-data-pipelines.html" style="text-decoration: none; color: inherit;">Designing Reliable Batch Data Pipelines</a></h3>
-                </header>
-                <p style="font-size: 0.875rem;">Why "retry until success" isn't a strategy. Patterns for building robust ETL systems that sleep well at night.</p>
-                <footer>
-                        <a href="blog/batch-data-pipelines.html" class="button small outline">Read article</a>
-                </footer>
-            </article>
-
-            <!-- Featured Post 3 -->
-            <article class="card">
-                    <header>
-                    <div class="text-muted" style="font-size: 0.75rem;">Python</div>
-                    <h3><a href="blog/python-performance.html" style="text-decoration: none; color: inherit;">Python Performance: Where It Breaks and Why</a></h3>
-                </header>
-                <p style="font-size: 0.875rem;">Python is slow, but your code doesn't have to be. Examining the GIL, memory management, and when to drop to C.</p>
-                <footer>
-                        <a href="blog/python-performance.html" class="button small outline">Read article</a>
-                </footer>
-            </article>
+            <!-- Project 2 -->
+            <div class="card-border-glow" style="padding: 2rem; border-radius: 0.5rem; display: flex; flex-direction: column; height: 100%;">
+                <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; margin-bottom: 1rem;">Distributed Consensus Engine</h3>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin-bottom: 2rem; flex-grow: 1;">
+                    Implemented a simplified Raft consensus algorithm in Python for a distributed key-value store, focusing on leader election and log replication.
+                </p>
+                <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-top: auto;">
+                    <span>[ Python ]</span>
+                    <span>[ gRPC ]</span>
+                    <span>[ Redis ]</span>
+                </div>
+            </div>
         </div>
     </section>
+    <!-- END: Featured Projects -->
+
+    <!-- BEGIN: Latest Thoughts -->
+    <section style="margin-bottom: 6rem;">
+        <h2 style="font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700; margin-bottom: 2rem;">Latest Thoughts</h2>
+
+        <div class="grid-2-col">
+            <!-- Article 1 -->
+            <a href="blog/postgres-query-planning.html" class="card-border-glow" style="display: block; padding: 2rem; border-radius: 0.5rem; text-decoration: none; display: flex; flex-direction: column; height: 100%;">
+                <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; color: var(--foreground); transition: color 0.2s;" onmouseover="this.style.color='var(--terminal-green)'" onmouseout="this.style.color='var(--foreground)'">How Postgres Query Planning Actually Works</h3>
+                <div style="font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-bottom: 1rem;">Oct 26, 2024</div>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Understanding the optimizer's cost models is critical for writing high-performance queries. We dive deep into access methods and index utilization.
+                </p>
+            </a>
+
+            <!-- Article 2 -->
+            <a href="blog/batch-data-pipelines.html" class="card-border-glow" style="display: block; padding: 2rem; border-radius: 0.5rem; text-decoration: none; display: flex; flex-direction: column; height: 100%;">
+                <h3 style="font-family: var(--font-serif); font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; color: var(--foreground); transition: color 0.2s;" onmouseover="this.style.color='var(--terminal-green)'" onmouseout="this.style.color='var(--foreground)'">Designing Reliable Batch Data Pipelines</h3>
+                <div style="font-family: var(--font-mono); font-size: 0.75rem; color: #6b7280; margin-bottom: 1rem;">Sep 14, 2024</div>
+                <p style="color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.625; margin: 0;">
+                    Why "retry until success" is not a strategy. Exploring patterns for building robust, recoverable ETL workflows that don't wake you up at 3 AM.
+                </p>
+            </a>
+        </div>
+    </section>
+    <!-- END: Latest Thoughts -->
 {% endblock %}


### PR DESCRIPTION
* Add terminal-themed CSS variables, color palette, and glowing effects
* Replace standard fonts with Fira Code and Zilla Slab combinations
* Implement browser top-bar and CLI footer navigation elements
* Redesign index page with Hero section, engineering principles grid, and glowing project/thought cards
* Update `base.html` template and correctly migrate layout across `projects.html`, `resume.html`, and generated pages
* Re-generate static assets using python build script
* Retain pure vanilla CSS/HTML without relying on external frontend frameworks